### PR TITLE
Implement XBot Interfaces for the Gazebo Plugin in separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,20 @@ target_link_libraries(JointImpedanceController JointController ${GAZEBO_LIBRARIE
 add_library(DefaultGazeboPID SHARED src/DefaultGazeboPID.cpp)
 target_link_libraries(DefaultGazeboPID JointController ${GAZEBO_LIBRARIES} )
 
+add_library(GazeboXBotJoint SHARED src/GazeboXBotJoint.cpp)
+target_link_libraries(GazeboXBotJoint   ${GAZEBO_LIBRARIES}
+                                        yaml-cpp
+                                        JointImpedanceController )
+
+add_library(GazeboXBotImu SHARED src/GazeboXBotImu.cpp)
+target_link_libraries(GazeboXBotImu ${GAZEBO_LIBRARIES} )
+
+add_library(GazeboXBotFt SHARED src/GazeboXBotFt.cpp)
+target_link_libraries(GazeboXBotFt ${GAZEBO_LIBRARIES} )
+
+add_library(GazeboXBotHand SHARED src/GazeboXBotHand.cpp)
+target_link_libraries(GazeboXBotHand ${GAZEBO_LIBRARIES} )
+
 # GazeboXBotPlugin
 add_library(GazeboXBotPlugin SHARED src/GazeboXBotPlugin.cpp)
 target_link_libraries(GazeboXBotPlugin ${GAZEBO_LIBRARIES}
@@ -60,6 +74,10 @@ target_link_libraries(GazeboXBotPlugin ${GAZEBO_LIBRARIES}
                                        JointController
                                        DefaultGazeboPID
                                        JointImpedanceController
+                                       GazeboXBotJoint
+                                       GazeboXBotImu
+                                       GazeboXBotFt
+                                       GazeboXBotHand
                                        )
 
 install(TARGETS GazeboXBotPlugin RUNTIME LIBRARY DESTINATION lib)
@@ -82,4 +100,7 @@ install(DIRECTORY include/
         DESTINATION include
         FILES_MATCHING PATTERN "*.h*")
 
-
+install(TARGETS GazeboXBotJoint RUNTIME LIBRARY DESTINATION lib)
+install(TARGETS GazeboXBotImu RUNTIME LIBRARY DESTINATION lib)
+install(TARGETS GazeboXBotFt RUNTIME LIBRARY DESTINATION lib)
+install(TARGETS GazeboXBotHand RUNTIME LIBRARY DESTINATION lib)

--- a/include/GazeboXBotPlugin/GazeboXBotFt.h
+++ b/include/GazeboXBotPlugin/GazeboXBotFt.h
@@ -1,0 +1,56 @@
+#ifndef __GAZEBO_XBOT_FT_H__
+#define __GAZEBO_XBOT_FT_H__
+
+#include <gazebo/sensors/ForceTorqueSensor.hh>
+
+#include <XBotCore-interfaces/All.h>
+
+#include <XBotInterface/XBotInterface.h>
+
+namespace gazebo
+{
+class GazeboXBotFt :
+    public XBot::IXBotFT
+
+{
+
+public :
+    /**
+     * @brief constructor
+     *
+     */
+    GazeboXBotFt();
+
+    /**
+     * @brief destructor
+     *
+     */
+    virtual ~GazeboXBotFt();
+
+    bool loadFTSensors(
+        XBot::RobotInterface::Ptr robot,
+        gazebo::sensors::Sensor_V& _sensors_attached_to_robot);
+
+protected:
+
+private:
+
+    // xbot robot
+    XBot::RobotInterface::Ptr _robot;
+
+    // ft callback helpers
+    std::map<int, gazebo::sensors::ForceTorqueSensorPtr> _ft_gazebo_map;
+
+    // NOTE IXBotFT
+    
+    virtual bool get_ft(int ft_id, std::vector< double >& ft, int channels = 6) final;
+
+    virtual bool get_ft_fault(int ft_id, double& fault) final;
+
+    virtual bool get_ft_rtt(int ft_id, double& rtt) final;
+    
+};
+
+}
+
+#endif

--- a/include/GazeboXBotPlugin/GazeboXBotHand.h
+++ b/include/GazeboXBotPlugin/GazeboXBotHand.h
@@ -1,0 +1,57 @@
+
+#ifndef __GAZEBO_XBOT_HAND_H__
+#define __GAZEBO_XBOT_HAND_H__
+
+#include <XBotCore-interfaces/All.h>
+
+#include <XBotInterface/XBotInterface.h>
+
+#include <std_msgs/Bool.h>
+#include <ros/ros.h>
+
+namespace gazebo
+{
+class GazeboXBotHand :
+    public XBot::IXBotHand
+{
+
+public :
+    /**
+     * @brief constructor
+     *
+     */
+    GazeboXBotHand();
+
+    /**
+     * @brief destructor
+     *
+     */
+    virtual ~GazeboXBotHand();
+
+    void initGrasping(
+        XBot::RobotInterface::Ptr robot);
+
+    void grasp_status_Callback(const std_msgs::Bool::ConstPtr& msg, int hand_id);
+    
+protected:
+
+private:
+    // xbot robot
+    XBot::RobotInterface::Ptr _robot;
+    
+    //grasping
+    std::map<int, ros::Publisher> _grasp;
+    std::map<int, ros::Subscriber> _state_grasp;
+    std::map<int, bool> _status_grasp;
+        
+    std::shared_ptr<ros::NodeHandle> _nh;
+
+    virtual bool grasp(int hand_id, double grasp_percentage) final;
+    
+    virtual double get_grasp_state(int hand_id) final;
+
+};
+
+}
+
+#endif

--- a/include/GazeboXBotPlugin/GazeboXBotImu.h
+++ b/include/GazeboXBotPlugin/GazeboXBotImu.h
@@ -1,0 +1,56 @@
+#ifndef __GAZEBO_XBOT_IMU_H__
+#define __GAZEBO_XBOT_IMU_H__
+
+#include <gazebo/sensors/ImuSensor.hh>
+
+#include <XBotCore-interfaces/All.h>
+
+#include <XBotInterface/XBotInterface.h>
+
+namespace gazebo
+{
+class GazeboXBotImu :
+    public XBot::IXBotIMU
+{
+
+public :
+    /**
+     * @brief constructor
+     *
+     */
+    GazeboXBotImu();
+
+    /**
+     * @brief destructor
+     *
+     */
+    virtual ~GazeboXBotImu();
+
+    bool loadImuSensors(
+        XBot::RobotInterface::Ptr robot,
+        gazebo::sensors::Sensor_V& _sensors_attached_to_robot);
+
+protected:
+
+private:
+    // xbot robot
+    XBot::RobotInterface::Ptr _robot;
+    
+    // imu callback helpers
+    std::map<int, gazebo::sensors::ImuSensorPtr> _imu_gazebo_map;
+
+    // NOTE IXBotIMU 
+    virtual bool get_imu(int imu_id, std::vector< double >& lin_acc,
+                         std::vector< double >& ang_vel,
+                         std::vector< double >& quaternion) final;
+
+    virtual bool get_imu_fault(int imu_id, double& fault) final;
+
+    virtual bool get_imu_rtt(int imu_id, double& rtt) final;
+
+
+};
+
+}
+
+#endif

--- a/include/GazeboXBotPlugin/GazeboXBotJoint.h
+++ b/include/GazeboXBotPlugin/GazeboXBotJoint.h
@@ -1,0 +1,101 @@
+
+#ifndef __GAZEBO_XBOT_JOINT_H__
+#define __GAZEBO_XBOT_JOINT_H__
+
+#include <XBotCore-interfaces/All.h>
+
+#include <XBotInterface/XBotInterface.h>
+
+#include <GazeboXBotPlugin/JointController.h>
+
+namespace gazebo
+{
+class GazeboXBotJoint :
+    public XBot::IXBotJoint
+{
+
+public :
+    /**
+     * @brief constructor
+     *
+     */
+    GazeboXBotJoint();
+
+    /**
+     * @brief destructor
+     *
+     */
+    virtual ~GazeboXBotJoint();
+
+    bool loadJoints(XBot::RobotInterface::Ptr robot, physics::ModelPtr model, YAML::Node& root);
+    
+    void XBotUpdate();
+    
+protected:
+
+private:
+    // xbot robot
+    XBot::RobotInterface::Ptr _robot;
+    
+    // Gazebo joint names vector
+    std::vector<std::string> _jointNames;
+
+    // Gazebo joint map
+    std::map<std::string, gazebo::physics::JointPtr> _jointMap;
+    std::map<std::string, XBot::JointController::Ptr> _joint_controller_map;
+
+    gazebo::physics::JointPtr getJoint(int joint_id);
+    XBot::JointController::Ptr getJointController(int joint_id);
+  
+
+    // NOTE IXBotJoint getters
+    virtual bool get_link_pos(int joint_id, double& link_pos) final;
+
+    virtual bool get_motor_pos(int joint_id, double& motor_pos) final;
+
+    virtual bool get_link_vel(int joint_id, double& link_vel) final;
+
+    virtual bool get_motor_vel(int joint_id, double& motor_vel) final;
+
+    virtual bool get_torque(int joint_id, double& torque) final;
+
+    virtual bool get_temperature(int joint_id, double& temperature) final;
+
+    virtual bool get_gains(int joint_id, std::vector<double>& gain_vector) final;
+
+    virtual bool get_fault(int joint_id, double& fault) final;
+
+    virtual bool get_rtt(int joint_id, double& rtt) final;
+
+    virtual bool get_op_idx_ack(int joint_id, double& op_idx_ack) final;
+
+    virtual bool get_aux(int joint_id, double& aux) final;
+
+    virtual bool get_pos_ref(int joint_id, double& pos_ref) final;
+
+    virtual bool get_vel_ref(int joint_id, double& vel_ref) final;
+
+    virtual bool get_tor_ref(int joint_id, double& tor_ref) final;
+
+    // NOTE IXBotJoint setters
+    virtual bool set_pos_ref(int joint_id, const double& pos_ref) final;
+
+    virtual bool set_vel_ref(int joint_id, const double& vel_ref) final;
+
+    virtual bool set_tor_ref(int joint_id, const double& tor_ref) final;
+
+    virtual bool set_gains(int joint_id, const std::vector<double>& gains) final;
+
+    virtual bool set_fault_ack(int joint_id, const double& fault_ack) final;
+
+    virtual bool set_ts(int joint_id, const double& ts) final;
+
+    virtual bool set_op_idx_aux(int joint_id, const double& op_idx_aux) final;
+
+    virtual bool set_aux(int joint_id, const double& aux) final;
+
+};
+
+}
+
+#endif

--- a/include/GazeboXBotPlugin/GazeboXBotPlugin.h
+++ b/include/GazeboXBotPlugin/GazeboXBotPlugin.h
@@ -37,18 +37,16 @@
 
 #include <GazeboXBotPlugin/JointController.h>
 #include <GazeboXBotPlugin/CallbackHelper.h>
-#include <std_msgs/Bool.h>
-#include <ros/ros.h>
+#include <GazeboXBotPlugin/GazeboXBotJoint.h>
+#include <GazeboXBotPlugin/GazeboXBotImu.h>
+#include <GazeboXBotPlugin/GazeboXBotFt.h>
+#include <GazeboXBotPlugin/GazeboXBotHand.h>
 
 
 namespace gazebo
 {
 class GazeboXBotPlugin :
-    public ModelPlugin,
-    public XBot::IXBotJoint, 
-    public XBot::IXBotIMU,
-    public XBot::IXBotFT,
-    public XBot::IXBotHand
+    public ModelPlugin
 
 {
 
@@ -102,19 +100,11 @@ private:
 
     bool loadPlugins();
     
-    bool loadFTSensors();
-
-    bool loadImuSensors();
-
     bool initPlugins();
 
     void close_all();
 
     double get_time();
-    
-    void initGrasping();
-    
-    void grasp_status_Callback(const std_msgs::Bool::ConstPtr& msg, int hand_id);
 
 
     // xbot robot
@@ -132,18 +122,14 @@ private:
     // previous iteration time (for keeping 1kHz control rate)
     double _previous_time;
 
-    // robot map
-    std::map<std::string, std::vector<int>> _XBotRobot;
-
     // path to config file
     std::string _path_to_config;
 
-    // Gazebo joint names vector
-    std::vector<std::string> _jointNames;
-
-    // Gazebo joint map
-    std::map<std::string, gazebo::physics::JointPtr> _jointMap;
-    std::map<std::string, XBot::JointController::Ptr> _joint_controller_map;
+    std::shared_ptr<GazeboXBotJoint> _xbot_joint;
+    std::shared_ptr<GazeboXBotImu> _xbot_imu;
+    std::shared_ptr<GazeboXBotFt> _xbot_ft;
+    std::shared_ptr<GazeboXBotHand> _xbot_hand;
+    
 
     // model
     physics::ModelPtr _model;
@@ -159,96 +145,6 @@ private:
 
     // gazebo transport node
     gazebo::transport::NodePtr _node;
-    
-    // gazebo sensors
-    gazebo::sensors::Sensor_V _sensors;
-    
-    // gazebo sensors attached to the current robot
-    gazebo::sensors::Sensor_V _sensors_attached_to_robot;
-    
-    // imu callback helpers
-    std::map<int, gazebo::sensors::ImuSensorPtr> _imu_gazebo_map;
-    // ft callback helpers
-    std::map<int, gazebo::sensors::ForceTorqueSensorPtr> _ft_gazebo_map;
-    
-    
-    //grasping
-    std::map<int, ros::Publisher> _grasp;
-    std::map<int, ros::Subscriber> _state_grasp;
-    std::map<int, bool> _status_grasp;
-        
-    std::shared_ptr<ros::NodeHandle> _nh;
-
-    // NOTE IXBotJoint getters
-    virtual bool get_link_pos(int joint_id, double& link_pos) final;
-
-    virtual bool get_motor_pos(int joint_id, double& motor_pos) final;
-
-    virtual bool get_link_vel(int joint_id, double& link_vel) final;
-
-    virtual bool get_motor_vel(int joint_id, double& motor_vel) final;
-
-    virtual bool get_torque(int joint_id, double& torque) final;
-
-    virtual bool get_temperature(int joint_id, double& temperature) final;
-
-    virtual bool get_gains(int joint_id, std::vector<double>& gain_vector) final;
-
-    virtual bool get_fault(int joint_id, double& fault) final;
-
-    virtual bool get_rtt(int joint_id, double& rtt) final;
-
-    virtual bool get_op_idx_ack(int joint_id, double& op_idx_ack) final;
-
-    virtual bool get_aux(int joint_id, double& aux) final;
-
-    virtual bool get_pos_ref(int joint_id, double& pos_ref) final;
-
-    virtual bool get_vel_ref(int joint_id, double& vel_ref) final;
-
-    virtual bool get_tor_ref(int joint_id, double& tor_ref) final;
-
-    // NOTE IXBotJoint setters
-    virtual bool set_pos_ref(int joint_id, const double& pos_ref) final;
-
-    virtual bool set_vel_ref(int joint_id, const double& vel_ref) final;
-
-    virtual bool set_tor_ref(int joint_id, const double& tor_ref) final;
-
-    virtual bool set_gains(int joint_id, const std::vector<double>& gains) final;
-
-    virtual bool set_fault_ack(int joint_id, const double& fault_ack) final;
-
-    virtual bool set_ts(int joint_id, const double& ts) final;
-
-    virtual bool set_op_idx_aux(int joint_id, const double& op_idx_aux) final;
-
-    virtual bool set_aux(int joint_id, const double& aux) final;
-
-    // NOTE IXBotFT
-    
-    virtual bool get_ft(int ft_id, std::vector< double >& ft, int channels = 6) final;
-
-    virtual bool get_ft_fault(int ft_id, double& fault) final;
-
-    virtual bool get_ft_rtt(int ft_id, double& rtt) final;
-    
-    
-    // NOTE IXBotIMU 
-    virtual bool get_imu(int imu_id, std::vector< double >& lin_acc,
-                         std::vector< double >& ang_vel,
-                         std::vector< double >& quaternion) final;
-
-    virtual bool get_imu_fault(int imu_id, double& fault) final;
-
-    virtual bool get_imu_rtt(int imu_id, double& rtt) final;
-    
-    //NOTE IXBotHand
-    virtual bool grasp(int hand_id, double grasp_percentage) final;
-    
-    virtual double get_grasp_state(int hand_id) final;
-
-
 };
 
 // Register this plugin with the simulator

--- a/src/GazeboXBotFt.cpp
+++ b/src/GazeboXBotFt.cpp
@@ -1,0 +1,114 @@
+
+#include<GazeboXBotPlugin/GazeboXBotFt.h>
+
+
+gazebo::GazeboXBotFt::GazeboXBotFt()
+{
+}
+
+gazebo::GazeboXBotFt::~GazeboXBotFt()
+{
+}
+
+bool gazebo::GazeboXBotFt::loadFTSensors(XBot::RobotInterface::Ptr robot, gazebo::sensors::Sensor_V& _sensors_attached_to_robot)
+{
+    _robot = robot;
+    
+    std::cout << __PRETTY_FUNCTION__ << std::endl;
+    bool ret = true;
+    std::cout << "Loading F-T sensors ... " << std::endl;
+    
+    for( const auto& FT_pair : _robot->getForceTorque() ) {
+
+        // check XBot FT ptr
+        if(!FT_pair.second){
+            std::cout << "ERROR! FT NULLPTR!!!" << std::endl;
+            continue;
+        }
+
+        // get id and name of the FT sensor
+        const XBot::ForceTorqueSensor& ft = *FT_pair.second;
+        int ft_id = ft.getSensorId();
+        std::string ft_name = ft.getSensorName();
+
+        for(unsigned int i = 0; i < _sensors_attached_to_robot.size(); ++i) {
+            #if GAZEBO_MAJOR_VERSION <= 6
+            // if the sensor is a FT and has the ft_name
+            if( ( _sensors_attached_to_robot[i]->GetType().compare("force_torque") == 0 ) &&
+                ( _sensors_attached_to_robot[i]->GetName() == ft_name ) )
+            {
+                _ft_gazebo_map[ft_id] = boost::static_pointer_cast<gazebo::sensors::ForceTorqueSensor>(_sensors_attached_to_robot[i]); 
+                std::cout << "F-T found: " << _ft_gazebo_map.at(ft_id)->GetName() << std::endl;
+            }
+            #else 
+            if( ( _sensors_attached_to_robot[i]->Type().compare("force_torque") == 0 ) &&
+                ( _sensors_attached_to_robot[i]->Name() == ft_name ) )
+            {
+                _ft_gazebo_map[ft_id] = std::static_pointer_cast<gazebo::sensors::ForceTorqueSensor>(_sensors_attached_to_robot[i]); 
+                std::cout << "F-T found: " << _ft_gazebo_map.at(ft_id)->Name() << std::endl;
+            }
+            #endif
+
+        }
+        
+    }
+
+    return ret;
+}
+
+bool gazebo::GazeboXBotFt::get_ft(int ft_id, std::vector< double >& ft, int channels)
+{
+    auto it =_ft_gazebo_map.find(ft_id);
+    // if ft is not found
+    if( it == _ft_gazebo_map.end() ) {
+        std::cout << "WARNING: FT with id : " << ft_id << " not found in the GAZEBO model you loaded: check you put the right urdf_path, srdf_path and joint_config_map in your YAML config file." << std::endl;
+        return false;
+    }
+
+    // imu found
+    auto ft_gazebo = it->second;
+
+    ft.assign(channels, 0.0);
+
+    if( !ft_gazebo ) {
+        ft.assign(channels, 0.0);
+        return false;
+    }
+
+    ft[0] = ft_gazebo->Force().X();
+    ft[1] = ft_gazebo->Force().Y();
+    ft[2] = ft_gazebo->Force().Z();
+    ft[3] = ft_gazebo->Torque().X();
+    ft[4] = ft_gazebo->Torque().Y();
+    ft[5] = ft_gazebo->Torque().Z();
+
+    return true;
+}
+
+bool gazebo::GazeboXBotFt::get_ft_fault(int ft_id, double& fault)
+{
+    auto ft_ptr = _robot->getForceTorque(ft_id);
+
+    if(!ft_ptr){
+        fault = 0;
+        return false;
+    }
+
+    fault = 0;
+    return true;
+}
+
+bool gazebo::GazeboXBotFt::get_ft_rtt(int ft_id, double& rtt)
+{
+    auto ft_ptr = _robot->getForceTorque(ft_id);
+
+    if(!ft_ptr){
+        rtt = 0;
+        return false;
+    }
+
+    rtt = 0;
+    return true;
+}
+
+

--- a/src/GazeboXBotHand.cpp
+++ b/src/GazeboXBotHand.cpp
@@ -1,0 +1,72 @@
+
+#include<GazeboXBotPlugin/GazeboXBotHand.h>
+
+
+gazebo::GazeboXBotHand::GazeboXBotHand()
+{
+}
+
+gazebo::GazeboXBotHand::~GazeboXBotHand()
+{
+}
+
+
+void gazebo::GazeboXBotHand::grasp_status_Callback(const std_msgs::Bool::ConstPtr& msg, int hand_id)
+{
+  
+  _status_grasp[hand_id] = msg.get()->data;
+  return;
+}
+
+
+void gazebo::GazeboXBotHand::initGrasping(
+        XBot::RobotInterface::Ptr robot)
+{
+    _robot = robot;
+    
+    int argc = 1;
+    const char *arg = "MagneticGrasping";
+    char* argg = const_cast<char*>(arg);
+    char** argv = &argg;
+
+    if(!ros::isInitialized()){
+        ros::init(argc, argv, "MagneticGrasping");
+    }
+      
+    _nh = std::make_shared<ros::NodeHandle>();
+   
+    for( auto& pair : _robot->getHand()){      
+      std::string hand_name= pair.second->getHandName();
+      int hand_id = pair.second->getHandId();
+      std::string hand_link =_robot->getUrdf().getJoint(hand_name)->parent_link_name;
+      _grasp[hand_id] = _nh->advertise<std_msgs::Bool>("/grasp/"+hand_link+"/autoGrasp",1);
+      _state_grasp[hand_id] = _nh->subscribe<std_msgs::Bool>("/grasp/"+hand_link+"/state", 1, boost::bind(&gazebo::GazeboXBotHand::grasp_status_Callback,this,_1,hand_id));
+      _status_grasp[hand_id] = false;
+      
+    }
+    
+}
+
+bool gazebo::GazeboXBotHand::grasp(int hand_id, double grasp_percentage)
+{
+    std_msgs::Bool message;    
+    
+    if(grasp_percentage == 0)
+      message.data = false;
+    else
+      message.data = true;
+    
+    _grasp[hand_id].publish (message);
+  
+  return true;
+}
+    
+double gazebo::GazeboXBotHand::get_grasp_state(int hand_id)
+{
+  
+   double grasp_state = 0;
+   grasp_state = _status_grasp[hand_id];
+       
+   return grasp_state;
+}
+

--- a/src/GazeboXBotImu.cpp
+++ b/src/GazeboXBotImu.cpp
@@ -1,0 +1,133 @@
+
+#include<GazeboXBotPlugin/GazeboXBotImu.h>
+
+
+gazebo::GazeboXBotImu::GazeboXBotImu()
+{
+}
+
+gazebo::GazeboXBotImu::~GazeboXBotImu()
+{
+}
+
+bool gazebo::GazeboXBotImu::loadImuSensors(XBot::RobotInterface::Ptr robot, gazebo::sensors::Sensor_V& _sensors_attached_to_robot)
+{
+    _robot = robot;
+    
+    std::cout << __PRETTY_FUNCTION__ << std::endl;
+    bool ret = true;
+    std::cout << "Loading IMU sensors ... " << std::endl;
+    
+    for( const auto& imu_pair : _robot->getImu() ) {
+
+        // check XBot FT ptr
+        if(!imu_pair.second){
+            std::cout << "ERROR! imu NULLPTR!!!" << std::endl;
+            continue;
+        }
+
+        // get id and name of the FT sensor
+        const XBot::ImuSensor& imu = *imu_pair.second;
+        int imu_id = imu.getSensorId();
+        std::string imu_name = imu.getSensorName();
+
+        for(unsigned int i = 0; i < _sensors_attached_to_robot.size(); ++i) {
+            #if GAZEBO_MAJOR_VERSION <= 6
+            // if the sensor is a IMU and has the ft_name
+            if( ( _sensors_attached_to_robot[i]->GetType().compare("imu") == 0 ) &&
+                ( _sensors_attached_to_robot[i]->GetName() == imu_name ) )
+            {
+                _imu_gazebo_map[imu_id] = boost::static_pointer_cast<gazebo::sensors::ImuSensor>(_sensors_attached_to_robot[i]); 
+                std::cout << "IMU found: " << _imu_gazebo_map.at(imu_id)->GetName() << std::endl;
+            }
+            #else 
+            if( ( _sensors_attached_to_robot[i]->Type().compare("imu") == 0 ) &&
+                ( _sensors_attached_to_robot[i]->Name() == imu_name ) )
+            {
+                _imu_gazebo_map[imu_id] = std::static_pointer_cast<gazebo::sensors::ImuSensor>(_sensors_attached_to_robot[i]); 
+                std::cout << "IMU found: " << _imu_gazebo_map.at(imu_id)->Name() << std::endl;
+            }
+            #endif
+
+        }
+        
+    }
+    
+    return ret;
+}
+
+bool gazebo::GazeboXBotImu::get_imu(int imu_id,
+                                       std::vector< double >& lin_acc,
+                                       std::vector< double >& ang_vel,
+                                       std::vector< double >& quaternion)
+{
+
+    auto it =_imu_gazebo_map.find(imu_id);
+    // if imu is not found
+    if( it == _imu_gazebo_map.end() ) {
+        std::cout << "WARNING: IMU with id : " << imu_id << " not found in the GAZEBO model you loaded: check you put the right urdf_path, srdf_path and joint_config_map in your YAML config file." << std::endl;
+        return false;
+    }
+
+    // imu found
+    auto imu_gazebo = it->second;
+    
+    lin_acc.assign(3, 0.0);
+    ang_vel.assign(3, 0.0);
+    quaternion.assign(4, 0.0);
+    quaternion[3] = 1.0;
+
+    if(!imu_gazebo){
+        lin_acc.assign(3, 0.0);
+        ang_vel.assign(3, 0.0);
+        quaternion.assign(4, 0.0);
+        quaternion[3] = 1.0;
+
+        return false;
+    }
+
+    lin_acc[0] = imu_gazebo->LinearAcceleration().X();
+    lin_acc[1] = imu_gazebo->LinearAcceleration().Y();
+    lin_acc[2] = imu_gazebo->LinearAcceleration().Z();
+
+    ang_vel[0] = imu_gazebo->AngularVelocity().X();
+    ang_vel[1] = imu_gazebo->AngularVelocity().Y();
+    ang_vel[2] = imu_gazebo->AngularVelocity().Z();
+
+    quaternion[0] = imu_gazebo->Orientation().X();
+    quaternion[1] = imu_gazebo->Orientation().Y();
+    quaternion[2] = imu_gazebo->Orientation().Z();
+    quaternion[3] = imu_gazebo->Orientation().W();
+    
+    return true;
+
+
+}
+
+bool gazebo::GazeboXBotImu::get_imu_fault(int imu_id, double& fault)
+{
+    auto imu_ptr = _robot->getImu(imu_id);
+
+    if(!imu_ptr){
+        fault = 0;
+        return false;
+    }
+
+    fault = 0;
+    return true;
+}
+
+bool gazebo::GazeboXBotImu::get_imu_rtt(int imu_id, double& rtt)
+{
+    auto imu_ptr = _robot->getImu(imu_id);
+
+    if(!imu_ptr){
+        rtt = 0;
+        return false;
+    }
+
+    rtt = 0;
+    return true;
+}
+
+

--- a/src/GazeboXBotJoint.cpp
+++ b/src/GazeboXBotJoint.cpp
@@ -1,0 +1,343 @@
+
+#include<GazeboXBotPlugin/GazeboXBotJoint.h>
+
+#include <GazeboXBotPlugin/JointImpedanceController.h>
+
+
+gazebo::GazeboXBotJoint::GazeboXBotJoint()
+{
+}
+
+gazebo::GazeboXBotJoint::~GazeboXBotJoint()
+{
+}
+
+bool gazebo::GazeboXBotJoint::loadJoints(XBot::RobotInterface::Ptr robot, physics::ModelPtr model, YAML::Node& root)
+{
+    _robot = robot;
+    
+    // iterate over Gazebo model Joint vector and store Joint pointers in a map
+    const gazebo::physics::Joint_V & gazebo_models_joints = model->GetJoints();
+    for (unsigned int gazebo_joint = 0; gazebo_joint < gazebo_models_joints.size(); gazebo_joint++) {
+        std::string gazebo_joint_name = gazebo_models_joints[gazebo_joint]->GetName();
+
+        if(std::find(_robot->getEnabledJointNames().begin(),
+                  _robot->getEnabledJointNames().end(), gazebo_joint_name) ==
+                _robot->getEnabledJointNames().end())
+        {
+            std::cout << gazebo_joint_name<<" is not present in the list of enabled joints, ";
+            std::cout << " therefore will not be controlled by XBot!" << std::endl;
+            continue;
+        }
+
+
+        _jointNames.push_back(gazebo_joint_name);
+        _jointMap[gazebo_joint_name] = model->GetJoint(gazebo_joint_name);
+
+        _joint_controller_map[gazebo_joint_name] =
+            std::make_shared<XBot::JointImpedanceController>( model->GetJoint(gazebo_joint_name) );
+
+        double p_gain = 300;
+        double d_gain = 1;
+
+        if( root["GazeboXBotPlugin"]["gains"][gazebo_joint_name] ){
+            p_gain = root["GazeboXBotPlugin"]["gains"][gazebo_joint_name]["p"].as<double>();
+            d_gain = root["GazeboXBotPlugin"]["gains"][gazebo_joint_name]["d"].as<double>();
+        }
+
+
+        _joint_controller_map.at(gazebo_joint_name)->setGains(p_gain, 0, d_gain);
+
+        _joint_controller_map.at(gazebo_joint_name)->enableFeedforward();
+
+        std::cout << "Joint # " << gazebo_joint << " - " << gazebo_joint_name << std::endl;
+
+    }
+    
+    return true;
+}
+
+void gazebo::GazeboXBotJoint::XBotUpdate()
+{
+    for( auto& pair : _joint_controller_map ){
+        pair.second->sendControlInput();
+    }
+}
+
+gazebo::physics::JointPtr gazebo::GazeboXBotJoint::getJoint(int joint_id)
+{
+    if (!_robot)
+        return 0;
+
+    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
+    if (current_joint_name == "")
+        return 0;
+        
+    auto it = _jointMap.find(current_joint_name);
+    if (it == _jointMap.end())
+        return 0;
+    
+    return it->second;
+}
+
+XBot::JointController::Ptr gazebo::GazeboXBotJoint::getJointController(int joint_id)
+{
+
+    if (!_robot)
+        return 0;
+
+    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
+    if (current_joint_name == "")
+        return 0;
+        
+    auto it = _joint_controller_map.find(current_joint_name);
+    if (it == _joint_controller_map.end())
+        return 0;
+    
+    return it->second;
+}
+
+
+
+bool gazebo::GazeboXBotJoint::get_link_pos ( int joint_id, double& link_pos )
+{
+    auto j(getJoint(joint_id));
+
+    if(j) {
+        link_pos = j->GetAngle(0).Radian();
+        return true;
+    }
+    else {
+        link_pos = 0;
+        return false;
+    }
+}
+
+bool gazebo::GazeboXBotJoint::get_aux ( int joint_id, double& aux )
+{
+    aux = 0;
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::get_fault ( int joint_id, double& fault )
+{
+    fault = 0;
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::get_link_vel ( int joint_id, double& link_vel )
+{
+    auto j(getJoint(joint_id));
+
+    if(j) {
+        link_vel = j->GetVelocity(0);
+        return true;
+    }
+    else {
+        link_vel = 0;
+        return false;
+    }
+}
+
+bool gazebo::GazeboXBotJoint::get_temperature ( int joint_id, double& temperature )
+{
+    temperature = 0;
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::get_gains(int joint_id, std::vector< double >& gain_vector)
+{
+
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        if(gain_vector.size() < 2){
+            gain_vector.assign(2, 0);
+        }
+        gain_vector[0] = j->getP();
+        gain_vector[1] = j->getD();
+
+        return true;
+    }
+
+    return false;
+}
+
+
+bool gazebo::GazeboXBotJoint::get_motor_pos ( int joint_id, double& motor_pos )
+{
+    auto j(getJoint(joint_id));
+
+    if(j) {
+        motor_pos = j->GetAngle(0).Radian();
+        // NOTE we return true but we are reading the link position from gazebo TBD a plugin should simulate this
+        return true;
+    }
+    else {
+        motor_pos = 0;
+        return false;
+    }
+}
+
+bool gazebo::GazeboXBotJoint::get_motor_vel ( int joint_id, double& motor_vel )
+{
+    auto j(getJoint(joint_id));
+
+    if(j) {
+        motor_vel = j->GetVelocity(0);
+        // NOTE we return false but we are reading the link position drom gazebo TBD a plugin should simulate this
+        return true;
+    }
+    else {
+        motor_vel = 0;
+        return false;
+    }
+}
+
+bool gazebo::GazeboXBotJoint::get_op_idx_ack ( int joint_id, double& op_idx_ack )
+{
+    op_idx_ack = 0;
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::get_rtt ( int joint_id, double& rtt )
+{
+    // TBD is it possible to get this info??
+    rtt = 0;
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::get_torque ( int joint_id, double& torque )
+{
+    auto j(getJoint(joint_id));
+
+    if(j) {
+        torque = j->GetForce(0);
+        return true;
+    }
+    else {
+        torque = 0;
+        return false;
+    }
+}
+
+bool gazebo::GazeboXBotJoint::get_pos_ref(int joint_id, double& pos_ref)
+{
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        pos_ref = j->getPositionReference();
+        return true;
+    }
+
+    return false;
+}
+
+
+bool gazebo::GazeboXBotJoint::get_vel_ref(int joint_id, double& vel_ref)
+{
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        vel_ref = j->getVelocityReference();
+        return true;
+    }
+
+    return false;
+}
+
+
+bool gazebo::GazeboXBotJoint::get_tor_ref(int joint_id, double& tor_ref)
+{
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        tor_ref = j->getTorqueReference();
+        return true;
+    }
+
+    return false;
+}
+
+
+bool gazebo::GazeboXBotJoint::set_aux ( int joint_id, const double& aux )
+{
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_fault_ack ( int joint_id, const double& fault_ack )
+{
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_gains ( int joint_id, const std::vector< double >& gains )
+{
+    if(gains.size() < 2){
+        std::cerr << "ERROR in " << __func__ << "! Provided gains vector size is " << gains.size() << " less than 2!" << std::endl;
+        return false;
+    }
+
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        j->setGains(gains[0], 0, gains[1]);
+        return true;
+    }
+
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_op_idx_aux ( int joint_id, const double& op_idx_aux )
+{
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_pos_ref ( int joint_id, const double& pos_ref )
+{
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        j->setPositionReference(pos_ref);
+        return true;
+    }
+
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_tor_ref ( int joint_id, const double& tor_ref )
+{
+    auto j(getJointController(joint_id));
+
+    if(j) {
+        j->setTorqueReference(double(tor_ref)); // NOTE torque scaling random but suitable to avoid the int16t overflow
+        return true;
+    }
+
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_ts ( int joint_id, const double& ts )
+{
+    return false;
+}
+
+bool gazebo::GazeboXBotJoint::set_vel_ref ( int joint_id, const double& vel_ref )
+{
+    // TBD support velocity reference
+
+//     std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
+//     auto it = _jointMap.find(current_joint_name);
+//
+//     if(current_joint_name != "" && it != _jointMap.end()) {
+//         _model->GetJointController()->SetVelocityTarget((it->second)->GetScopedName(), vel_ref);
+//         _model->GetJointController()->Update();
+//         return true;
+//     }
+
+    return false;
+
+}
+
+
+
+

--- a/src/GazeboXBotPlugin.cpp
+++ b/src/GazeboXBotPlugin.cpp
@@ -29,7 +29,6 @@
 #include<GazeboXBotPlugin/GazeboXBotPlugin.h>
 
 #include <GazeboXBotPlugin/DefaultGazeboPID.h>
-#include <GazeboXBotPlugin/JointImpedanceController.h>
 
 #include <gazebo/sensors/sensors.hh>
 
@@ -55,13 +54,6 @@ gazebo::GazeboXBotPlugin::~GazeboXBotPlugin()
     close_all();
 }
 
-
-void gazebo::GazeboXBotPlugin::grasp_status_Callback(const std_msgs::Bool::ConstPtr& msg, int hand_id)
-{
-  
-  _status_grasp[hand_id] = msg.get()->data;
-  return;
-}
 
 void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 {
@@ -96,10 +88,14 @@ void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
 
     // create robot from config file and any map
     XBot::AnyMapPtr anymap = std::make_shared<XBot::AnyMap>();
-    std::shared_ptr<XBot::IXBotJoint> xbot_joint(this, [](XBot::IXBotJoint* p){});
-    std::shared_ptr<XBot::IXBotFT> xbot_ft(this, [](XBot::IXBotFT* p){});
-    std::shared_ptr<XBot::IXBotIMU> xbot_imu(this, [](XBot::IXBotIMU* p){});
-    std::shared_ptr<XBot::IXBotHand> xbot_hand(this, [](XBot::IXBotHand* p){});
+    _xbot_joint = std::make_shared<GazeboXBotJoint>();
+    _xbot_imu = std::make_shared<GazeboXBotImu>();
+    _xbot_ft = std::make_shared<GazeboXBotFt>();
+    _xbot_hand = std::make_shared<GazeboXBotHand>();
+    std::shared_ptr<XBot::IXBotJoint> xbot_joint = _xbot_joint;
+    std::shared_ptr<XBot::IXBotFT> xbot_ft = _xbot_ft;
+    std::shared_ptr<XBot::IXBotIMU> xbot_imu = _xbot_imu;
+    std::shared_ptr<XBot::IXBotHand> xbot_hand = _xbot_hand;
     (*anymap)["XBotJoint"] = boost::any(xbot_joint);
     (*anymap)["XBotFT"] = boost::any(xbot_ft);
     (*anymap)["XBotIMU"] = boost::any(xbot_imu);
@@ -107,7 +103,7 @@ void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
 
     // initialize the robot
     _robot = XBot::RobotInterface::getRobot(_path_to_config, anymap, "XBotRT");
-    
+
     // create time provider function
     boost::function<double()> time_func = boost::bind(&gazebo::GazeboXBotPlugin::get_time, this);
     // create time provider
@@ -116,44 +112,7 @@ void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
     // create plugin handler
     _pluginHandler = std::make_shared<XBot::PluginHandler>(_robot, time_provider, "XBotRTPlugins");
 
-    // iterate over Gazebo model Joint vector and store Joint pointers in a map
-    const gazebo::physics::Joint_V & gazebo_models_joints = _model->GetJoints();
-    for (unsigned int gazebo_joint = 0; gazebo_joint < gazebo_models_joints.size(); gazebo_joint++) {
-        std::string gazebo_joint_name = gazebo_models_joints[gazebo_joint]->GetName();
-
-        if(std::find(_robot->getEnabledJointNames().begin(),
-                  _robot->getEnabledJointNames().end(), gazebo_joint_name) ==
-                _robot->getEnabledJointNames().end())
-        {
-            std::cout << gazebo_joint_name<<" is not present in the list of enabled joints, ";
-            std::cout << " therefore will not be controlled by XBot!" << std::endl;
-            continue;
-        }
-
-
-        _jointNames.push_back(gazebo_joint_name);
-        _jointMap[gazebo_joint_name] = _model->GetJoint(gazebo_joint_name);
-
-        // setting gains
-        _joint_controller_map[gazebo_joint_name] =
-            std::make_shared<XBot::JointImpedanceController>( _model->GetJoint(gazebo_joint_name) );
-
-            double p_gain = 300;
-            double d_gain = 1;
-
-        // setting the gains
-        if( root["GazeboXBotPlugin"]["gains"][gazebo_joint_name] ){
-            p_gain = root["GazeboXBotPlugin"]["gains"][gazebo_joint_name]["p"].as<double>();
-            d_gain = root["GazeboXBotPlugin"]["gains"][gazebo_joint_name]["d"].as<double>();
-        }
-
-
-        _joint_controller_map.at(gazebo_joint_name)->setGains(p_gain, 0, d_gain);
-        _joint_controller_map.at(gazebo_joint_name)->enableFeedforward();
-
-        std::cout << "Joint # " << gazebo_joint << " - " << gazebo_joint_name << std::endl;
-
-    }
+    _xbot_joint->loadJoints(_robot, _model, root);
 
     // set the control rate
     if(root["GazeboXBotPlugin"]["control_rate"]){
@@ -164,8 +123,13 @@ void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
         _control_rate = 0.001;
     }
     
+    // gazebo sensors
     // get the list of sensors
-    _sensors = gazebo::sensors::SensorManager::Instance()->GetSensors();
+    gazebo::sensors::Sensor_V _sensors = gazebo::sensors::SensorManager::Instance()->GetSensors();
+    
+    // gazebo sensors attached to the current robot
+    gazebo::sensors::Sensor_V _sensors_attached_to_robot;
+    
     
     // if multiple robot are simulated we need to get only the sensors attached to our robot
     for(unsigned int i = 0; i < _sensors.size(); ++i) {
@@ -183,101 +147,13 @@ void gazebo::GazeboXBotPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
     }
 
     // load FT sensors
-    loadFTSensors();
+    _xbot_ft->loadFTSensors(_robot, _sensors_attached_to_robot);
 
     // load IMU sensors
-    loadImuSensors();
+    _xbot_imu->loadImuSensors(_robot, _sensors_attached_to_robot);
+
 
 }
-
-bool gazebo::GazeboXBotPlugin::loadFTSensors()
-{
-    std::cout << __PRETTY_FUNCTION__ << std::endl;
-    bool ret = true;
-    std::cout << "Loading F-T sensors ... " << std::endl;
-    
-    for( const auto& FT_pair : _robot->getForceTorque() ) {
-
-        // check XBot FT ptr
-        if(!FT_pair.second){
-            std::cout << "ERROR! FT NULLPTR!!!" << std::endl;
-            continue;
-        }
-
-        // get id and name of the FT sensor
-        const XBot::ForceTorqueSensor& ft = *FT_pair.second;
-        int ft_id = ft.getSensorId();
-        std::string ft_name = ft.getSensorName();
-
-        for(unsigned int i = 0; i < _sensors_attached_to_robot.size(); ++i) {
-            #if GAZEBO_MAJOR_VERSION <= 6
-            // if the sensor is a FT and has the ft_name
-            if( ( _sensors_attached_to_robot[i]->GetType().compare("force_torque") == 0 ) &&
-                ( _sensors_attached_to_robot[i]->GetName() == ft_name ) )
-            {
-                _ft_gazebo_map[ft_id] = boost::static_pointer_cast<gazebo::sensors::ForceTorqueSensor>(_sensors_attached_to_robot[i]); 
-                std::cout << "F-T found: " << _ft_gazebo_map.at(ft_id)->GetName() << std::endl;
-            }
-            #else 
-            if( ( _sensors_attached_to_robot[i]->Type().compare("force_torque") == 0 ) &&
-                ( _sensors_attached_to_robot[i]->Name() == ft_name ) )
-            {
-                _ft_gazebo_map[ft_id] = std::static_pointer_cast<gazebo::sensors::ForceTorqueSensor>(_sensors_attached_to_robot[i]); 
-                std::cout << "F-T found: " << _ft_gazebo_map.at(ft_id)->Name() << std::endl;
-            }
-            #endif
-
-        }
-        
-    }
-
-    return ret;
-}
-
-bool gazebo::GazeboXBotPlugin::loadImuSensors()
-{
-    std::cout << __PRETTY_FUNCTION__ << std::endl;
-    bool ret = true;
-    std::cout << "Loading IMU sensors ... " << std::endl;
-    
-    for( const auto& imu_pair : _robot->getImu() ) {
-
-        // check XBot FT ptr
-        if(!imu_pair.second){
-            std::cout << "ERROR! imu NULLPTR!!!" << std::endl;
-            continue;
-        }
-
-        // get id and name of the FT sensor
-        const XBot::ImuSensor& imu = *imu_pair.second;
-        int imu_id = imu.getSensorId();
-        std::string imu_name = imu.getSensorName();
-
-        for(unsigned int i = 0; i < _sensors_attached_to_robot.size(); ++i) {
-            #if GAZEBO_MAJOR_VERSION <= 6
-            // if the sensor is a IMU and has the ft_name
-            if( ( _sensors_attached_to_robot[i]->GetType().compare("imu") == 0 ) &&
-                ( _sensors_attached_to_robot[i]->GetName() == imu_name ) )
-            {
-                _imu_gazebo_map[imu_id] = boost::static_pointer_cast<gazebo::sensors::ImuSensor>(_sensors_attached_to_robot[i]); 
-                std::cout << "IMU found: " << _imu_gazebo_map.at(imu_id)->GetName() << std::endl;
-            }
-            #else 
-            if( ( _sensors_attached_to_robot[i]->Type().compare("imu") == 0 ) &&
-                ( _sensors_attached_to_robot[i]->Name() == imu_name ) )
-            {
-                _imu_gazebo_map[imu_id] = std::static_pointer_cast<gazebo::sensors::ImuSensor>(_sensors_attached_to_robot[i]); 
-                std::cout << "IMU found: " << _imu_gazebo_map.at(imu_id)->Name() << std::endl;
-            }
-            #endif
-
-        }
-        
-    }
-    
-    return ret;
-}
-
 
 void gazebo::GazeboXBotPlugin::Init()
 {
@@ -292,9 +168,9 @@ void gazebo::GazeboXBotPlugin::Init()
 
     // Set _previous_time
     _previous_time = get_time();
-    
+
     // init grasping ROS node
-    initGrasping();
+    _xbot_hand->initGrasping(_robot);
 }
 
 bool gazebo::GazeboXBotPlugin::loadPlugins()
@@ -304,34 +180,7 @@ bool gazebo::GazeboXBotPlugin::loadPlugins()
 
 bool gazebo::GazeboXBotPlugin::initPlugins()
 {
-    std::shared_ptr<XBot::IXBotJoint> xbot_joint(this);
-    return _pluginHandler->init_plugins(_shared_memory, xbot_joint);
-}
-
-void gazebo::GazeboXBotPlugin::initGrasping()
-{
-    
-    int argc = 1;
-    const char *arg = "MagneticGrasping";
-    char* argg = const_cast<char*>(arg);
-    char** argv = &argg;
-
-    if(!ros::isInitialized()){
-        ros::init(argc, argv, "MagneticGrasping");
-    }
-      
-    _nh = std::make_shared<ros::NodeHandle>();
-   
-    for( auto& pair : _robot->getHand()){      
-      std::string hand_name= pair.second->getHandName();
-      int hand_id = pair.second->getHandId();
-      std::string hand_link =_robot->getUrdf().getJoint(hand_name)->parent_link_name;
-      _grasp[hand_id] = _nh->advertise<std_msgs::Bool>("/grasp/"+hand_link+"/autoGrasp",1);
-      _state_grasp[hand_id] = _nh->subscribe<std_msgs::Bool>("/grasp/"+hand_link+"/state", 1, boost::bind(&gazebo::GazeboXBotPlugin::grasp_status_Callback,this,_1,hand_id));
-      _status_grasp[hand_id] = false;
-      
-    }
-    
+    return _pluginHandler->init_plugins(_shared_memory, _xbot_joint);
 }
 
 void gazebo::GazeboXBotPlugin::close_all()
@@ -365,9 +214,7 @@ void gazebo::GazeboXBotPlugin::XBotUpdate(const common::UpdateInfo & _info)
 
     }
 
-    for( auto& pair : _joint_controller_map ){
-        pair.second->sendControlInput();
-    }
+    _xbot_joint->XBotUpdate();
 }
 
 void gazebo::GazeboXBotPlugin::Reset()
@@ -375,413 +222,6 @@ void gazebo::GazeboXBotPlugin::Reset()
     gazebo::ModelPlugin::Reset();
 }
 
-
-
-bool gazebo::GazeboXBotPlugin::get_link_pos ( int joint_id, double& link_pos )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _jointMap.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _jointMap.end()) {
-        link_pos = (it->second)->GetAngle(0).Radian();
-        return true;
-    }
-    else {
-        link_pos = 0;
-        return false;
-    }
-}
-
-bool gazebo::GazeboXBotPlugin::get_aux ( int joint_id, double& aux )
-{
-    aux = 0;
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::get_fault ( int joint_id, double& fault )
-{
-    fault = 0;
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::get_link_vel ( int joint_id, double& link_vel )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _jointMap.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _jointMap.end()) {
-        link_vel = (it->second)->GetVelocity(0);
-        return true;
-    }
-    else {
-        link_vel = 0;
-        return false;
-    }
-}
-
-bool gazebo::GazeboXBotPlugin::get_temperature ( int joint_id, double& temperature )
-{
-    temperature = 0;
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::get_gains(int joint_id, std::vector< double >& gain_vector)
-{
-
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()){
-        if(gain_vector.size() < 2){
-            gain_vector.assign(2, 0);
-        }
-        gain_vector[0] = it->second->getP();
-        gain_vector[1] = it->second->getD();
-
-        return true;
-    }
-
-    return false;
-}
-
-
-bool gazebo::GazeboXBotPlugin::get_motor_pos ( int joint_id, double& motor_pos )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _jointMap.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _jointMap.end()) {
-        motor_pos = (it->second)->GetAngle(0).Radian();
-        // NOTE we return true but we are reading the link position from gazebo TBD a plugin should simulate this
-        return true;
-    }
-    else {
-        motor_pos = 0;
-        return false;
-    }
-}
-
-bool gazebo::GazeboXBotPlugin::get_motor_vel ( int joint_id, double& motor_vel )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _jointMap.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _jointMap.end()) {
-        motor_vel = (it->second)->GetVelocity(0);
-        // NOTE we return false but we are reading the link position drom gazebo TBD a plugin should simulate this
-        return true;
-    }
-    else {
-        motor_vel = 0;
-        return false;
-    }
-}
-
-bool gazebo::GazeboXBotPlugin::get_op_idx_ack ( int joint_id, double& op_idx_ack )
-{
-    op_idx_ack = 0;
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::get_rtt ( int joint_id, double& rtt )
-{
-    // TBD is it possible to get this info??
-    rtt = 0;
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::get_torque ( int joint_id, double& torque )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _jointMap.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _jointMap.end()) {
-        torque = (it->second)->GetForce(0);
-        return true;
-    }
-    else {
-        torque = 0;
-        return false;
-    }
-}
-
-bool gazebo::GazeboXBotPlugin::get_pos_ref(int joint_id, double& pos_ref)
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        pos_ref = it->second->getPositionReference();
-        return true;
-    }
-
-    return false;
-}
-
-
-bool gazebo::GazeboXBotPlugin::get_vel_ref(int joint_id, double& vel_ref)
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        vel_ref = it->second->getVelocityReference();
-        return true;
-    }
-
-    return false;
-}
-
-
-bool gazebo::GazeboXBotPlugin::get_tor_ref(int joint_id, double& tor_ref)
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        tor_ref = it->second->getTorqueReference();
-        return true;
-    }
-
-    return false;
-}
-
-
-bool gazebo::GazeboXBotPlugin::set_aux ( int joint_id, const double& aux )
-{
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_fault_ack ( int joint_id, const double& fault_ack )
-{
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_gains ( int joint_id, const std::vector< double >& gains )
-{
-    if(gains.size() < 2){
-        std::cerr << "ERROR in " << __func__ << "! Provided gains vector size is " << gains.size() << " less than 2!" << std::endl;
-        return false;
-    }
-
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        it->second->setGains(gains[0], 0, gains[1]);
-        return true;
-    }
-
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_op_idx_aux ( int joint_id, const double& op_idx_aux )
-{
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_pos_ref ( int joint_id, const double& pos_ref )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        it->second->setPositionReference(pos_ref);
-        return true;
-    }
-
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_tor_ref ( int joint_id, const double& tor_ref )
-{
-    std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-    auto it = _joint_controller_map.find(current_joint_name);
-
-    if(current_joint_name != "" && it != _joint_controller_map.end()) {
-        it->second->setTorqueReference(double(tor_ref)); // NOTE torque scaling random but suitable to avoid the int16t overflow
-        return true;
-    }
-
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_ts ( int joint_id, const double& ts )
-{
-    return false;
-}
-
-bool gazebo::GazeboXBotPlugin::set_vel_ref ( int joint_id, const double& vel_ref )
-{
-    // TBD support velocity reference
-
-//     std::string current_joint_name = _robot->getJointByID(joint_id)->getJointName();
-//     auto it = _jointMap.find(current_joint_name);
-//
-//     if(current_joint_name != "" && it != _jointMap.end()) {
-//         _model->GetJointController()->SetVelocityTarget((it->second)->GetScopedName(), vel_ref);
-//         _model->GetJointController()->Update();
-//         return true;
-//     }
-
-    return false;
-
-}
-
-bool gazebo::GazeboXBotPlugin::get_imu(int imu_id,
-                                       std::vector< double >& lin_acc,
-                                       std::vector< double >& ang_vel,
-                                       std::vector< double >& quaternion)
-{
-
-    auto it =_imu_gazebo_map.find(imu_id);
-    // if imu is not found
-    if( it == _imu_gazebo_map.end() ) {
-        std::cout << "WARNING: IMU with id : " << imu_id << " not found in the GAZEBO model you loaded: check you put the right urdf_path, srdf_path and joint_config_map in your YAML config file." << std::endl;
-        return false;
-    }
-
-    // imu found
-    auto imu_gazebo = it->second;
-    
-    lin_acc.assign(3, 0.0);
-    ang_vel.assign(3, 0.0);
-    quaternion.assign(4, 0.0);
-    quaternion[3] = 1.0;
-
-    if(!imu_gazebo){
-        lin_acc.assign(3, 0.0);
-        ang_vel.assign(3, 0.0);
-        quaternion.assign(4, 0.0);
-        quaternion[3] = 1.0;
-
-        return false;
-    }
-
-    lin_acc[0] = imu_gazebo->LinearAcceleration().X();
-    lin_acc[1] = imu_gazebo->LinearAcceleration().Y();
-    lin_acc[2] = imu_gazebo->LinearAcceleration().Z();
-
-    ang_vel[0] = imu_gazebo->AngularVelocity().X();
-    ang_vel[1] = imu_gazebo->AngularVelocity().Y();
-    ang_vel[2] = imu_gazebo->AngularVelocity().Z();
-
-    quaternion[0] = imu_gazebo->Orientation().X();
-    quaternion[1] = imu_gazebo->Orientation().Y();
-    quaternion[2] = imu_gazebo->Orientation().Z();
-    quaternion[3] = imu_gazebo->Orientation().W();
-    
-    return true;
-
-
-}
-
-bool gazebo::GazeboXBotPlugin::get_imu_fault(int imu_id, double& fault)
-{
-    auto imu_ptr = _robot->getImu(imu_id);
-
-    if(!imu_ptr){
-        fault = 0;
-        return false;
-    }
-
-    fault = 0;
-    return true;
-}
-
-bool gazebo::GazeboXBotPlugin::get_imu_rtt(int imu_id, double& rtt)
-{
-    auto imu_ptr = _robot->getImu(imu_id);
-
-    if(!imu_ptr){
-        rtt = 0;
-        return false;
-    }
-
-    rtt = 0;
-    return true;
-}
-
-
-bool gazebo::GazeboXBotPlugin::get_ft(int ft_id, std::vector< double >& ft, int channels)
-{
-    auto it =_ft_gazebo_map.find(ft_id);
-    // if ft is not found
-    if( it == _ft_gazebo_map.end() ) {
-        std::cout << "WARNING: FT with id : " << ft_id << " not found in the GAZEBO model you loaded: check you put the right urdf_path, srdf_path and joint_config_map in your YAML config file." << std::endl;
-        return false;
-    }
-
-    // imu found
-    auto ft_gazebo = it->second;
-
-    ft.assign(channels, 0.0);
-
-    if( !ft_gazebo ) {
-        ft.assign(channels, 0.0);
-        return false;
-    }
-
-    ft[0] = ft_gazebo->Force().X();
-    ft[1] = ft_gazebo->Force().Y();
-    ft[2] = ft_gazebo->Force().Z();
-    ft[3] = ft_gazebo->Torque().X();
-    ft[4] = ft_gazebo->Torque().Y();
-    ft[5] = ft_gazebo->Torque().Z();
-
-    return true;
-}
-
-bool gazebo::GazeboXBotPlugin::get_ft_fault(int ft_id, double& fault)
-{
-    auto ft_ptr = _robot->getForceTorque(ft_id);
-
-    if(!ft_ptr){
-        fault = 0;
-        return false;
-    }
-
-    fault = 0;
-    return true;
-}
-
-bool gazebo::GazeboXBotPlugin::get_ft_rtt(int ft_id, double& rtt)
-{
-    auto ft_ptr = _robot->getForceTorque(ft_id);
-
-    if(!ft_ptr){
-        rtt = 0;
-        return false;
-    }
-
-    rtt = 0;
-    return true;
-}
-
-
-bool gazebo::GazeboXBotPlugin::grasp(int hand_id, double grasp_percentage)
-{
-    std_msgs::Bool message;    
-    
-    if(grasp_percentage == 0)
-      message.data = false;
-    else
-      message.data = true;
-    
-    _grasp[hand_id].publish (message);
-  
-  return true;
-}
-    
-double gazebo::GazeboXBotPlugin::get_grasp_state(int hand_id)
-{
-  
-   double grasp_state = 0;
-   grasp_state = _status_grasp[hand_id];
-       
-   return grasp_state;
-}
 
 
 bool gazebo::GazeboXBotPlugin::computeAbsolutePath (const std::string& input_path,


### PR DESCRIPTION
Since the Gazebo Plugin was implementing all the xbot interfaces, the file was large and difficult to handle.

This pull request performs a refactoring step separating the implementations of Joint, FT, IMU and Hand interfaces into explicit Classes.
